### PR TITLE
Add the ability to change the HipChat message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target/
 *.iml
 *.iws
 *.ipr
+
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <version>1.7.10</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmConstants.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmConstants.java
@@ -1,0 +1,11 @@
+package org.graylog2.alarmcallbacks.hipchat;
+
+public final class HipChatAlarmConstants {
+    protected static final String NAME = "HipChat alarm callback";
+    protected static final String CK_API_TOKEN = "api_token";
+    protected static final String CK_ROOM = "room";
+    protected static final String CK_COLOR = "color";
+    protected static final String CK_NOTIFY = "notify";
+    protected static final String CK_MSG_TEMPLATE = "msg_template";
+    protected static final String CK_API_URL = "api_url";
+}

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
@@ -47,7 +47,8 @@ public class HipChatAlarmCallbackTest {
                 "api_token", "TEST_api_token",
                 "room", "TEST_room",
                 "color", "yellow",
-                "notify", true
+                "notify", true,
+                "msg_template", "Stream template"
         ));
         alarmCallback.initialize(configuration);
     }
@@ -58,12 +59,13 @@ public class HipChatAlarmCallbackTest {
                 "api_token", "TEST_api_token",
                 "room", "TEST_room",
                 "color", "yellow",
-                "notify", true
+                "notify", true,
+                "msg_template", "Stream template"
         ));
         alarmCallback.initialize(configuration);
 
         final Map<String, Object> attributes = alarmCallback.getAttributes();
-        assertThat(attributes.keySet(), hasItems("api_token", "room", "color", "notify"));
+        assertThat(attributes.keySet(), hasItems("api_token", "room", "color", "notify", "msg_template"));
         assertThat((String) attributes.get("api_token"), equalTo("****"));
     }
 
@@ -73,8 +75,9 @@ public class HipChatAlarmCallbackTest {
         final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
                 "api_token", "TEST_api_token",
                 "room", "TEST_room",
-                "color", "yellow",
-                "notify", true
+                "color", "yellow",                
+                "notify", true,
+                "msg_template", "Stream template" 
 
         ));
         alarmCallback.initialize(configuration);
@@ -96,6 +99,19 @@ public class HipChatAlarmCallbackTest {
             throws AlarmCallbackConfigurationException, ConfigurationException {
         final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
                 "api_token", "TEST_api_token"
+        ));
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void checkConfigurationFailsIfMsgTemplateIsMissing()
+            throws AlarmCallbackConfigurationException, ConfigurationException {
+        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
+                "api_token", "TEST_api_token",
+                "room", "TEST_room",
+                "color", "yellow",                
+                "notify", true
         ));
         alarmCallback.initialize(configuration);
         alarmCallback.checkConfiguration();
@@ -127,11 +143,12 @@ public class HipChatAlarmCallbackTest {
     @Test
     public void testGetRequestedConfiguration() {
         assertThat(alarmCallback.getRequestedConfiguration().asList().keySet(),
-                hasItems("api_token", "room", "color", "notify"));
+                hasItems("api_token", "room", "color", "notify", "msg_template"));
     }
 
     @Test
     public void testGetName() {
         assertThat(alarmCallback.getName(), equalTo("HipChat alarm callback"));
     }
+
 }

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatTriggerTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatTriggerTest.java
@@ -1,0 +1,95 @@
+package org.graylog2.alarmcallbacks.hipchat;
+
+import static org.junit.Assert.assertEquals;
+
+import org.graylog2.plugin.alarms.AlertCondition;
+import org.graylog2.plugin.alarms.AlertCondition.CheckResult;
+import org.graylog2.plugin.alarms.callbacks.AlarmCallbackConfigurationException;
+import org.graylog2.plugin.alarms.callbacks.AlarmCallbackException;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationException;
+import org.graylog2.plugin.streams.Stream;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import static org.mockito.Mockito.*;
+
+public class HipChatTriggerTest {
+
+    private HipChatAlarmCallback alarmCallback;
+    private AlertCondition condition;
+    private Stream stream;
+    private CheckResult alert;
+    
+    @Before
+    public void setUp() {
+        alarmCallback = new HipChatAlarmCallback();
+        condition = mock(AlertCondition.class);
+        stream = mock(Stream.class);
+        alert = mock(CheckResult.class);
+        
+        when(condition.getStream()).thenReturn(stream);
+        when(condition.getStream().getTitle()).thenReturn("stream_name");		
+		when(alert.getResultDescription()).thenReturn("description");
+
+    }
+	
+    @Test
+    public void testMsgTemplateNameIsReplaced() 
+    		throws AlarmCallbackConfigurationException, ConfigurationException, AlarmCallbackException {
+        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
+                "api_token", "TEST_api_token",
+                "room", "TEST_room",
+                "color", "yellow",
+                "notify", true,
+                "msg_template", "Stream <<name>>"
+
+        ));
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+                
+        final HipChatTrigger trigger = new HipChatTrigger(configuration);
+
+        assertEquals(trigger.buildRoomNotification(condition, alert).message, "Stream <stream_name>");
+   }
+
+    @Test
+    public void testMsgTemplateDescriptionIsReplaced() 
+    		throws AlarmCallbackConfigurationException, ConfigurationException, AlarmCallbackException {
+        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
+                "api_token", "TEST_api_token",
+                "room", "TEST_room",
+                "color", "yellow",
+                "notify", true,
+                "msg_template", "Stream <description>"
+
+        ));
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+                
+        final HipChatTrigger trigger = new HipChatTrigger(configuration);
+
+        assertEquals(trigger.buildRoomNotification(condition, alert).message, "Stream description");
+   }
+
+    @Test
+    public void testMsgTemplateNameAndDescriptionAreReplaced() 
+    		throws AlarmCallbackConfigurationException, ConfigurationException, AlarmCallbackException {
+        final Configuration configuration = new Configuration(ImmutableMap.<String, Object>of(
+                "api_token", "TEST_api_token",
+                "room", "TEST_room",
+                "color", "yellow",
+                "notify", true,
+                "msg_template", "Stream <<name>> alert: <description>"
+
+        ));
+        alarmCallback.initialize(configuration);
+        alarmCallback.checkConfiguration();
+                
+        final HipChatTrigger trigger = new HipChatTrigger(configuration);
+
+        assertEquals(trigger.buildRoomNotification(condition, alert).message, "Stream <stream_name> alert: description");
+   }
+
+}


### PR DESCRIPTION
Hi,

I think we should be able to change the message sent to hipchat.

This PR add a new field called "Message template" to the callback configuration.
One can set its own message and use these two tokens :
- <name> : the stream name
- <description> : the alert description

As a default, the message template is : **Stream <<name>> alert: <description>** to be compatible with the default message by now.

Hope this helps,
Metin