### PR TITLE
Fixes #4: support for custom JMTE templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ and can be configured in your `graylog.conf` file.
 
 Restart `graylog-server` and you are done.
 
+## Usage
+
+Custom templates can be defined with the same [JMTE syntax](https://cdn.rawgit.com/DJCordhose/jmte/master/doc/index.html) used in [the email templates](http://docs.graylog.org/en/2.0/pages/streams.html#email-alert-callback), as long as they only work on the [HTML subset supported by the HipChat API](https://developer.atlassian.com/hipchat/guide/sending-messages).
+
+ For example, support for a custom field `myField` could look like:
+
+```html
+${if stream_url}<a href="${stream_url}">${end}
+<strong>Alert for ${stream.title}</strong>
+${if stream_url}
+</a>
+${end}
+<i>(${check_result.triggeredCondition})</i>
+<br/>
+<i>${check_result.resultDescription}, triggered at ${check_result.triggeredAt}</i>
+<br/>
+${if backlog}Last messages accounting for this alert:<br/>
+<table align="left">
+<tr><th>My Field</th><th>Details</th></tr>
+${foreach backlog message}<br/>
+<tr>
+    <td><b>${message.fields.myField}</b></td>
+    <td><code>${message.source}, ${message.id}</code></td>
+</tr>
+</table>
+${end}
+${else}
+<i>(No messages to display.)</i>
+${end}
+```
+
+If no custom template is given, the default email template is used.
+
 ## Build
 
 This project is using Maven and requires Java 7 or higher.

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
@@ -79,17 +79,17 @@ public class HipChatAlarmCallback implements AlarmCallback {
     }
 
     protected static URI getGraylogBaseUrl(Configuration configuration) throws AlarmCallbackException {
-        URI graylogBaseUrl = null;
         String graylogBaseUrlString = configuration.getString(CK_GRAYLOG_BASE_URL);
-        if (graylogBaseUrlString != null) {
-            try {
-                String urlWithoutTrailingSlash = graylogBaseUrlString.endsWith("/") ? graylogBaseUrlString.substring(0, graylogBaseUrlString.length() - 1) : graylogBaseUrlString;
-                graylogBaseUrl = new URI(urlWithoutTrailingSlash);
-            } catch (URISyntaxException e) {
-                throw new AlarmCallbackException("Graylog URL '" + graylogBaseUrlString + "' is not a valid URI.");
-            }
+        if (graylogBaseUrlString == null || graylogBaseUrlString.trim().isEmpty()) {
+            return null;
         }
-        return graylogBaseUrl;
+        try {
+            String urlWithoutTrailingSlash =
+                    graylogBaseUrlString.endsWith("/") ? graylogBaseUrlString.substring(0, graylogBaseUrlString.length() - 1) : graylogBaseUrlString;
+            return new URI(urlWithoutTrailingSlash);
+        } catch (URISyntaxException e) {
+            throw new AlarmCallbackException("Graylog URL '" + graylogBaseUrlString + "' is not a valid URI.");
+        }
     }
 
     @Override
@@ -146,8 +146,8 @@ public class HipChatAlarmCallback implements AlarmCallback {
                 CK_API_URL, "HipChat API URL", "https://api.hipchat.com",
                 "Specify different API URL for self hosted HipChat", ConfigurationField.Optional.OPTIONAL));
         configurationRequest.addField(new TextField(
-                CK_GRAYLOG_BASE_URL, "Graylog Base URL", "https://your.graylogserver.com/",
-                "Graylog base URL for linking to the stream.", ConfigurationField.Optional.OPTIONAL));
+                CK_GRAYLOG_BASE_URL, "Graylog Base URL", "",
+                "Graylog base URL for linking to the stream (e.g. https://your.graylogserver.com).", ConfigurationField.Optional.OPTIONAL));
         configurationRequest.addField(new TextField(
                 CK_MESSAGE_TEMPLATE, "Message Template", "",
                 "Custom message template (same as email templates).", ConfigurationField.Optional.OPTIONAL));

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
@@ -74,12 +74,11 @@ public class HipChatAlarmCallback implements AlarmCallback {
                 configuration.getBoolean(CK_NOTIFY),
                 configuration.getString(CK_API_URL),
                 configuration.getString(CK_MESSAGE_TEMPLATE),
-                getGraylogBaseUrl(configuration));
+                getGraylogBaseUrl(configuration.getString(CK_GRAYLOG_BASE_URL)));
         trigger.trigger(result.getTriggeredCondition(), result);
     }
 
-    protected static URI getGraylogBaseUrl(Configuration configuration) throws AlarmCallbackException {
-        String graylogBaseUrlString = configuration.getString(CK_GRAYLOG_BASE_URL);
+    protected static URI getGraylogBaseUrl(String graylogBaseUrlString) throws AlarmCallbackException {
         if (graylogBaseUrlString == null || graylogBaseUrlString.trim().isEmpty()) {
             return null;
         }

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
@@ -121,13 +121,17 @@ public class HipChatTrigger {
         }
     }
 
+    protected static boolean invalidTemplate(String template) {
+        return template == null || template.trim().isEmpty();
+    }
+
     //TODO: Copied and adapted from FormattedEmailAlertSender; could be refactored into a general utility for alerts?
     private String buildBody(AlertCondition condition, AlertCondition.CheckResult alert) {
         String template;
-        if (this.messageTemplate != null) {
-            template = this.messageTemplate;
-        } else {
+        if (invalidTemplate(this.messageTemplate)) {
             template = FormattedEmailAlertSender.bodyTemplate;
+        } else {
+            template = this.messageTemplate;
         }
         Map<String, Object> model = this.getModel(condition, alert);
         return this.engine.transform(template, model);

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
@@ -110,7 +110,7 @@ public class HipChatTrigger {
     }
 
     //TODO: Copied from StaticEmailAlertSender, could be moved to a utility class?
-    public static String buildStreamDetailsURL(URI baseUri, AlertCondition.CheckResult checkResult, Stream stream) {
+    public static String buildStreamDetailsURL(URI baseUri, AlertCondition.CheckResult checkResult, Stream stream) throws AlarmCallbackException {
         if (baseUri != null && !Strings.isNullOrEmpty(baseUri.getHost())) {
             int time = 5;
             if (checkResult.getTriggeredCondition().getParameters().get("time") != null) {
@@ -122,7 +122,7 @@ public class HipChatTrigger {
             String alertEnd = Tools.getISO8601String(dateAlertEnd);
             return baseUri + "/streams/" + stream.getId() + "/messages?rangetype=absolute&from=" + alertStart + "&to=" + alertEnd + "&q=*";
         } else {
-            return "Please configure \'transport_email_web_interface_url\' in your Graylog configuration file.";
+            throw new AlarmCallbackException("Please configure a valid Graylog Base URL in the alarm callback parameters.");
         }
     }
 
@@ -131,7 +131,7 @@ public class HipChatTrigger {
     }
 
     //TODO: Copied and adapted from FormattedEmailAlertSender; could be refactored into a general utility for alerts?
-    private String buildBody(AlertCondition condition, AlertCondition.CheckResult alert) {
+    private String buildBody(AlertCondition condition, AlertCondition.CheckResult alert) throws AlarmCallbackException {
         String template;
         if (invalidTemplate(this.messageTemplate)) {
             template = FormattedEmailAlertSender.bodyTemplate;
@@ -143,7 +143,7 @@ public class HipChatTrigger {
     }
 
     //TODO: Copied from FormattedEmailAlertSender
-    private Map<String, Object> getModel(AlertCondition condition, AlertCondition.CheckResult alert) {
+    private Map<String, Object> getModel(AlertCondition condition, AlertCondition.CheckResult alert) throws AlarmCallbackException {
         Stream stream = condition.getStream();
         List<Message> messages = new ArrayList<>();
         for (MessageSummary messageSummary : alert.getMatchingMessages()) {
@@ -160,7 +160,7 @@ public class HipChatTrigger {
         return model;
     }
 
-    private RoomNotification buildRoomNotification(AlertCondition condition, AlertCondition.CheckResult alert) {
+    private RoomNotification buildRoomNotification(AlertCondition condition, AlertCondition.CheckResult alert) throws AlarmCallbackException {
         final String message = this.buildBody(condition, alert);
         return new RoomNotification(message, color, notify);
     }

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
@@ -15,6 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.graylog2.alarmcallbacks.hipchat;
 
@@ -34,7 +35,11 @@ import org.joda.time.DateTime;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.*;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatTrigger.java
@@ -15,45 +15,58 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 package org.graylog2.alarmcallbacks.hipchat;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.floreysoft.jmte.Engine;
 import com.google.common.base.Strings;
+import org.graylog2.alerts.FormattedEmailAlertSender;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.alarms.AlertCondition;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallbackException;
+import org.graylog2.plugin.streams.Stream;
+import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
+import java.net.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HipChatTrigger {
+
     private final String apiToken;
     private final String room;
     private final String color;
     private final boolean notify;
     private final String apiURL;
+    private final String messageTemplate;
     private final ObjectMapper objectMapper;
+    private final URI graylogBaseUrl;
+    private final Engine engine = new Engine();
 
     public HipChatTrigger(final String apiToken, final String room, final String color, final boolean notify,
-                          final String apiURL) {
-        this(apiToken, room, color, notify, apiURL, new ObjectMapper());
+                          final String apiURL, final String messageTemplate, final URI graylogBaseUrl) {
+        this(apiToken, room, color, notify, apiURL, new ObjectMapper(), messageTemplate, graylogBaseUrl);
     }
 
-    HipChatTrigger(final String apiToken, final String room, final String color, final boolean notify, 
-                   final String apiURL, final ObjectMapper objectMapper) {
+    HipChatTrigger(final String apiToken, final String room, final String color, final boolean notify,
+                   final String apiURL, final ObjectMapper objectMapper, final String messageTemplate, final URI graylogBaseUrl) {
         this.apiToken = apiToken;
         this.room = room;
         this.color = color;
         this.notify = notify;
         this.apiURL = apiURL;
         this.objectMapper = objectMapper;
+        this.messageTemplate = messageTemplate;
+        this.graylogBaseUrl = graylogBaseUrl;
     }
 
     public void trigger(AlertCondition condition, AlertCondition.CheckResult alert) throws AlarmCallbackException {
@@ -91,23 +104,66 @@ public class HipChatTrigger {
         }
     }
 
-    private RoomNotification buildRoomNotification(AlertCondition condition, AlertCondition.CheckResult alert) {
-        // See https://www.hipchat.com/docs/apiv2/method/send_room_notification for valid parameters
-        final String message = String.format("Stream <%s> alert: %s",
-                condition.getStream().getTitle(),
-                alert.getResultDescription()
-        );
+    //TODO: Copied from StaticEmailAlertSender, could be moved to a utility class?
+    public static String buildStreamDetailsURL(URI baseUri, AlertCondition.CheckResult checkResult, Stream stream) {
+        if (baseUri != null && !Strings.isNullOrEmpty(baseUri.getHost())) {
+            int time = 5;
+            if (checkResult.getTriggeredCondition().getParameters().get("time") != null) {
+                time = ((Integer) checkResult.getTriggeredCondition().getParameters().get("time")).intValue();
+            }
+            DateTime dateAlertEnd = checkResult.getTriggeredAt();
+            DateTime dateAlertStart = dateAlertEnd.minusMinutes(time);
+            String alertStart = Tools.getISO8601String(dateAlertStart);
+            String alertEnd = Tools.getISO8601String(dateAlertEnd);
+            return baseUri + "/streams/" + stream.getId() + "/messages?rangetype=absolute&from=" + alertStart + "&to=" + alertEnd + "&q=*";
+        } else {
+            return "Please configure \'transport_email_web_interface_url\' in your Graylog configuration file.";
+        }
+    }
 
+    //TODO: Copied and adapted from FormattedEmailAlertSender; could be refactored into a general utility for alerts?
+    private String buildBody(AlertCondition condition, AlertCondition.CheckResult alert) {
+        String template;
+        if (this.messageTemplate != null) {
+            template = this.messageTemplate;
+        } else {
+            template = FormattedEmailAlertSender.bodyTemplate;
+        }
+        Map<String, Object> model = this.getModel(condition, alert);
+        return this.engine.transform(template, model);
+    }
+
+    //TODO: Copied from FormattedEmailAlertSender
+    private Map<String, Object> getModel(AlertCondition condition, AlertCondition.CheckResult alert) {
+        Stream stream = condition.getStream();
+        List<Message> messages = new ArrayList<>();
+        for (MessageSummary messageSummary : alert.getMatchingMessages()) {
+            messages.add(messageSummary.getRawMessage());
+        }
+        HashMap<String, Object> model = new HashMap<>();
+        model.put("stream", stream);
+        model.put("check_result", alert);
+        if (graylogBaseUrl != null) {
+            model.put("stream_url", buildStreamDetailsURL(graylogBaseUrl, alert, stream));
+        }
+        model.put("backlog", messages);
+        model.put("backlog_size", messages.size());
+        return model;
+    }
+
+    private RoomNotification buildRoomNotification(AlertCondition condition, AlertCondition.CheckResult alert) {
+        final String message = this.buildBody(condition, alert);
         return new RoomNotification(message, color, notify);
     }
 
+    // See https://www.hipchat.com/docs/apiv2/method/send_room_notification for valid parameters
     public static class RoomNotification {
         @JsonProperty
         public String message;
         @JsonProperty
         public boolean notify = true;
         @JsonProperty("message_format")
-        public final String messageFormat = "text";
+        public final String messageFormat = "html";
         @JsonProperty
         public String color = "yellow";
 

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
@@ -33,6 +33,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.graylog2.alarmcallbacks.hipchat.HipChatAlarmCallback.getGraylogBaseUrl;
+import static org.graylog2.alarmcallbacks.hipchat.HipChatTrigger.invalidTemplate;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.*;
@@ -166,5 +167,11 @@ public class HipChatAlarmCallbackTest {
                         "color", "INVALID",
                         "graylog_base_url", "invalid URI"
                 )));
+    }
+
+    @Test
+    public void invalidTemplateCheckOk() {
+        assertTrue(invalidTemplate(null));
+        assertTrue(invalidTemplate(" "));
     }
 }

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
@@ -145,31 +145,15 @@ public class HipChatAlarmCallbackTest {
 
     @Test
     public void graylogBaseUrlRetrievalWorks() throws AlarmCallbackException, URISyntaxException {
-        assertNull(getGraylogBaseUrl(
-                new Configuration(ImmutableMap.<String, Object>of(
-                        "api_token", "TEST_api_token",
-                        "room", "TEST_room",
-                        "color", "INVALID"
-                ))));
+        assertNull(getGraylogBaseUrl(null));
         assertEquals("Trailing '/' gets removed automatically",
                 new URI("https://test.graylog.com"), getGraylogBaseUrl(
-                        new Configuration(ImmutableMap.<String, Object>of(
-                                "api_token", "TEST_api_token",
-                                "room", "TEST_room",
-                                "color", "INVALID",
-                                "graylog_base_url", "https://test.graylog.com/"
-                        ))));
+                        "https://test.graylog.com/"));
     }
 
     @Test(expected = AlarmCallbackException.class)
     public void graylogBaseUrlRetrievalInvalidUri() throws AlarmCallbackException {
-        getGraylogBaseUrl(
-                new Configuration(ImmutableMap.<String, Object>of(
-                        "api_token", "TEST_api_token",
-                        "room", "TEST_room",
-                        "color", "INVALID",
-                        "graylog_base_url", "invalid URI"
-                )));
+        getGraylogBaseUrl("invalid URI");
     }
 
     @Test

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
@@ -33,6 +33,7 @@ import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.graylog2.alarmcallbacks.hipchat.HipChatAlarmCallback.getGraylogBaseUrl;
+import static org.graylog2.alarmcallbacks.hipchat.HipChatTrigger.buildStreamDetailsURL;
 import static org.graylog2.alarmcallbacks.hipchat.HipChatTrigger.invalidTemplate;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -154,6 +155,11 @@ public class HipChatAlarmCallbackTest {
     @Test(expected = AlarmCallbackException.class)
     public void graylogBaseUrlRetrievalInvalidUri() throws AlarmCallbackException {
         getGraylogBaseUrl("invalid URI");
+    }
+
+    @Test(expected = AlarmCallbackException.class)
+    public void buildStreamDetailsURLThrowsAlarmCallbackExceptionOnInvalidUrl() throws AlarmCallbackException, URISyntaxException {
+        buildStreamDetailsURL(new URI("http:///no/host"), null, null);
     }
 
     @Test

--- a/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
+++ b/src/test/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallbackTest.java
@@ -36,7 +36,10 @@ import static org.graylog2.alarmcallbacks.hipchat.HipChatAlarmCallback.getGraylo
 import static org.graylog2.alarmcallbacks.hipchat.HipChatTrigger.invalidTemplate;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HipChatAlarmCallbackTest {
     private HipChatAlarmCallback alarmCallback;


### PR DESCRIPTION
Added two optional parameters that allow to specify:
- a custom base URL from which the Graylog server can be reached
when used on the HipChat server
- a custom template that defaults to the email body

Instead of the 'text' message format, the HipChat API is now called
with message format 'html'.

Updated `HipChatAlarmCallbackTest` and `README` accordingly.

Added `TODO` tags in `HipChatTrigger` where I had to copy&paste code from `FormattedEmailAlertSender` and `StaticEmailAlertSender`. 
I guess this part of the code could be made much nicer (e.g. there is probably a better way to get the base URL of the Graylog server?), but it seems that this would require additional changes to the email processing.