### PR TITLE
Added the "TextArea" attribute to the Message Template input field.

### DIFF
--- a/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
+++ b/src/main/java/org/graylog2/alarmcallbacks/hipchat/HipChatAlarmCallback.java
@@ -149,7 +149,7 @@ public class HipChatAlarmCallback implements AlarmCallback {
                 "Graylog base URL for linking to the stream (e.g. https://your.graylogserver.com).", ConfigurationField.Optional.OPTIONAL));
         configurationRequest.addField(new TextField(
                 CK_MESSAGE_TEMPLATE, "Message Template", "",
-                "Custom message template (same as email templates).", ConfigurationField.Optional.OPTIONAL));
+                "Custom message template (same as email templates).", ConfigurationField.Optional.OPTIONAL, TextField.Attribute.TEXTAREA));
 
         return configurationRequest;
     }


### PR DESCRIPTION
This is a lot easier to read and to edit the template directly in the Graylog interface.